### PR TITLE
Create package.json for static site

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "synqra-os",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "serve public"
+  },
+  "dependencies": {
+    "serve": "^14.2.0"
+  }
+}


### PR DESCRIPTION
Add `package.json` to enable Railway to serve the static site.

---
<a href="https://cursor.com/background-agent?bcId=bc-37eeca45-0302-463f-9559-8b182b3d913e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37eeca45-0302-463f-9559-8b182b3d913e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

