### PR TITLE
Verify and open synqra deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # synqra-os
+
+## Deployment verification and auto-open
+
+Use the helper script to verify the Railway deployment, print recent logs, probe the public URL, and auto-open the live site.
+
+```bash
+scripts/verify_deploy.sh
+```
+
+Behavior:
+- Attempts to ensure Railway CLI is available and selects context
+- Shows recent logs (configurable via `LOG_SINCE`, `LOG_LINES`)
+- Derives the public URL via `railway status --service synqra-os --json | jq -r '.url'` (fallbacks to runtime env)
+- Probes the URL with `curl`
+- Auto-opens the URL in your default browser (`xdg-open`/`open`/`start`)
+
+Environment variables:
+- `RAILWAY_TOKEN` (optional)
+- `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT`, `RAILWAY_SERVICE_NAME` (default service: `synqra-os`)
+- `DEPLOY_URL` or `PUBLIC_URL` (optional manual override)
+- `LOG_SINCE` (default `30m`), `LOG_LINES` (default `200`)
+- `NO_OPEN=1` to skip opening the browser
+
+Example:
+```bash
+RAILWAY_SERVICE_NAME=synqra-os scripts/verify_deploy.sh
+```


### PR DESCRIPTION
Add auto-open deployment URL to `verify_deploy.sh` to automatically open the Synqra site in the browser after successful deployment verification.

---
<a href="https://cursor.com/background-agent?bcId=bc-150e6c47-7273-4dab-a1aa-4a28897b979c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-150e6c47-7273-4dab-a1aa-4a28897b979c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

