### PR TITLE
Add duplicate commit safeguard to deploy script

### DIFF
--- a/scripts/safeguard.sh
+++ b/scripts/safeguard.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# safeguard.sh - Prevent duplicate commits (double-squash protection)
+
+safeguard_check() {
+  echo "[safeguard] 🔍 Checking for duplicate commits..."
+
+  last_msg=$(git log -1 --pretty=%B || echo "")
+  prev_msg=$(git log -2 --pretty=%B | tail -n1 || echo "")
+
+  if [[ "$last_msg" == "$prev_msg" && -n "$last_msg" ]]; then
+    echo "[safeguard] ❌ Duplicate commit detected: '$last_msg'"
+    echo "[safeguard] Aborting deploy to prevent double-squash."
+    exit 1
+  fi
+
+  echo "[safeguard] ✅ No duplicate commits. Safe to continue."
+}
+
+export -f safeguard_check
+


### PR DESCRIPTION
Add `safeguard.sh` to prevent duplicate commits during deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eabf57a-6bb0-4153-8824-07744dfe74d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6eabf57a-6bb0-4153-8824-07744dfe74d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

