### PR TITLE
Generate and deploy cultural audio variants

### DIFF
--- a/.ecosa/jobs/NOID_CulturalFlagMode/audio_analyze_generate.yaml
+++ b/.ecosa/jobs/NOID_CulturalFlagMode/audio_analyze_generate.yaml
@@ -1,0 +1,22 @@
+analyze_track:
+  title: "Kitchen"
+  artist: "Westside Gunn"
+  target_emotion: "Luxury grind, boss calm, street prestige"
+  extract:
+    - rhythm_signature
+    - mood_curve (tension → release)
+    - lyrical_energy_style
+    - pacing_beats_per_section
+  output_format: "concept_map.json"
+create_original_audio:
+  reference: "concept_map.json"
+  tempo: 85
+  vibe: "Dark luxury + street symphony"
+  layers:
+    - sub_bass: "clean 808"
+    - percussion: "vinyl crack snare + hi-hat rolls"
+    - ambient_texture: "neon-teal pads"
+    - melodic_lead: "muted brass + AI vocal hums"
+  output:
+    format: "mp3,wav"
+    path: "/synqra/assets/audio/noid_drop001_theme"

--- a/.ecosa/jobs/NOID_CulturalFlagMode/job_20251006T193459Z.yaml
+++ b/.ecosa/jobs/NOID_CulturalFlagMode/job_20251006T193459Z.yaml
@@ -1,0 +1,22 @@
+analyze_track:
+  title: "Kitchen"
+  artist: "Westside Gunn"
+  target_emotion: "Luxury grind, boss calm, street prestige"
+  extract:
+    - rhythm_signature
+    - mood_curve (tension → release)
+    - lyrical_energy_style
+    - pacing_beats_per_section
+  output_format: "concept_map.json"
+create_original_audio:
+  reference: "concept_map.json"
+  tempo: 85
+  vibe: "Dark luxury + street symphony"
+  layers:
+    - sub_bass: "clean 808"
+    - percussion: "vinyl crack snare + hi-hat rolls"
+    - ambient_texture: "neon-teal pads"
+    - melodic_lead: "muted brass + AI vocal hums"
+  output:
+    format: "mp3,wav"
+    path: "/synqra/assets/audio/noid_drop001_theme"

--- a/.ecosa/jobs/NOID_CulturalFlagMode/job_20251006T193506Z.yaml
+++ b/.ecosa/jobs/NOID_CulturalFlagMode/job_20251006T193506Z.yaml
@@ -1,0 +1,20 @@
+generate_motion_asset:
+  brand: "NØID"
+  tagline: "Drive Unseen. Earn Smart."
+  motion_style: "cinematic burst + neon particle flare"
+  duration: "5–7s"
+  soundtrack: "/synqra/assets/audio/noid_drop001_theme"
+  export:
+    - mp4_square_1080x1080
+    - mp4_vertical_1080x1920
+    - gif_loop
+deploy_campaign:
+  name: "NOID_Drop001_KitchenMode"
+  channels:
+    - LinkedIn
+    - Instagram
+    - X
+  schedule: "Tues-Thurs 8AM EST"
+  hashtags: "#LuxuryAutomation #DriveUnseen #EarnSmart #AIGrind"
+  ai_feedback: "enabled"
+  qa_loop: "auto-tune caption length & image ratio"

--- a/.ecosa/queues/NOID_CulturalFlagMode.yaml
+++ b/.ecosa/queues/NOID_CulturalFlagMode.yaml
@@ -1,0 +1,34 @@
+workflow:
+  - phase: 1
+    name: "Cultural Signal Extraction"
+    run:
+      - bash /ecosa/scripts/analyze_vibe_signature.sh --track "J Dilla - People"
+      - bash /ecosa/scripts/map_cultural_tone.sh --regions "NA,EU,AF,AS"
+    summary: "Extracted rhythm + emotional tone blueprint from reference track."
+  - phase: 2
+    name: "Create Global Sound Variants"
+    run:
+      - bash /ecosa/scripts/generate_original_audio.sh --vibe_map /data/vibe_signature.json
+      - bash /ecosa/scripts/add_regional_instruments.sh --regions "SAF,JP,UK,US"
+    summary: "Generated unique, royalty-free audio variations for each region."
+  - phase: 3
+    name: "Motion & Flag Sync"
+    run:
+      - bash /ecosa/scripts/render_motion_assets.sh --theme "FlagPulse"
+      - bash /ecosa/scripts/embed_brand_signature.sh --logo "NOID"
+    summary: "Produced visual sequences that blend brand + national motifs."
+  - phase: 4
+    name: "Campaign Deployment"
+    run:
+      - bash /ecosa/scripts/schedule_synqra_posts.sh --category "Global Flag Drops"
+      - bash /ecosa/scripts/track_performance.sh --interval "daily"
+    summary: "Auto-scheduled multi-region drops with performance tracking."
+  - phase: 5
+    name: "Evolve + Learn"
+    run:
+      - bash /ecosa/scripts/analyze_regional_feedback.sh
+      - bash /ecosa/scripts/refine_audio_tone.sh --feedback /logs/performance.json
+    summary: "Refined tone and style based on audience feedback — system self-evolves."
+logging:
+  destination: "supabase:cultural_flag_mode_logs"
+  notify: "daily 23:59"

--- a/.ecosa/state/jobs.json
+++ b/.ecosa/state/jobs.json
@@ -1,0 +1,10 @@
+{
+  "jobs": [
+    {
+      "name": "audio_analyze_generate",
+      "queue": "NOID_CulturalFlagMode",
+      "createdAt": "2025-10-06T19:35:23.624Z",
+      "path": "/workspace/.ecosa/jobs/NOID_CulturalFlagMode/audio_analyze_generate.yaml"
+    }
+  ]
+}

--- a/.ecosa/state/queues.json
+++ b/.ecosa/state/queues.json
@@ -1,0 +1,9 @@
+{
+  "queues": [
+    {
+      "name": "NOID_CulturalFlagMode",
+      "createdAt": "2025-10-06T19:35:12.927Z",
+      "path": "/workspace/.ecosa/queues/NOID_CulturalFlagMode.yaml"
+    }
+  ]
+}

--- a/ecosa
+++ b/ecosa
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="/workspace/.ecosa"
+QUEUES_DIR="$BASE_DIR/queues"
+JOBS_DIR="$BASE_DIR/jobs"
+LOGS_DIR="$BASE_DIR/logs"
+
+usage() {
+  echo "Usage: ecosa queue create <name> | ecosa job create <queueName>" >&2
+}
+
+ensure_dirs() {
+  mkdir -p "$QUEUES_DIR" "$JOBS_DIR" "$LOGS_DIR"
+}
+
+require_stdin() {
+  if [ -t 0 ]; then
+    echo "Error: This command expects YAML via STDIN (heredoc)." >&2
+    exit 10
+  fi
+}
+
+cmd=${1:-}
+sub=${2:-}
+arg=${3:-}
+
+case "$cmd" in
+  queue)
+    case "$sub" in
+      create)
+        name=${arg:-}
+        if [ -z "$name" ]; then
+          echo "Error: Missing queue name" >&2
+          usage
+          exit 2
+        fi
+        ensure_dirs
+        outfile="$QUEUES_DIR/${name}.yaml"
+        require_stdin
+        tmpfile="$(mktemp)"
+        cat > "$tmpfile"
+        mv "$tmpfile" "$outfile"
+        echo "Queue '$name' created at $outfile"
+        ;;
+      *)
+        usage; exit 1;
+        ;;
+    esac
+    ;;
+  job)
+    case "$sub" in
+      create)
+        queue=${arg:-}
+        if [ -z "$queue" ]; then
+          echo "Error: Missing queue name for job creation" >&2
+          usage
+          exit 3
+        fi
+        ensure_dirs
+        if [ ! -f "$QUEUES_DIR/${queue}.yaml" ]; then
+          echo "Error: Queue '$queue' not found. Create it first." >&2
+          exit 4
+        fi
+        ts="$(date -u +%Y%m%dT%H%M%SZ)"
+        jobdir="$JOBS_DIR/${queue}"
+        mkdir -p "$jobdir"
+        outfile="$jobdir/job_${ts}.yaml"
+        require_stdin
+        tmpfile="$(mktemp)"
+        cat > "$tmpfile"
+        mv "$tmpfile" "$outfile"
+        echo "Job created for queue '$queue' at $outfile"
+        ;;
+      *)
+        usage; exit 1;
+        ;;
+    esac
+    ;;
+  *)
+    usage; exit 1;
+    ;;
+ esac

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "export:slides": "node scripts/exportSlides.js"
+    "export:slides": "node scripts/exportSlides.js",
+    "ecosa": "node scripts/ecosa.mjs"
   },
   "dependencies": {
     "file-saver": "^2.0.5",

--- a/scripts/ecosa.mjs
+++ b/scripts/ecosa.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+function ensureDir(path) {
+  mkdirSync(path, { recursive: true });
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    if (process.stdin.isTTY) return resolve('');
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (data += chunk));
+    process.stdin.on('end', () => resolve(data));
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const cmd = args[0];
+
+  if (cmd === 'queue' && args[1] === 'create') {
+    const name = args[2];
+    if (!name) {
+      console.error('Usage: ecosa queue create <name>');
+      process.exit(1);
+    }
+    const input = await readStdin();
+
+    // Use hidden workspace directory to avoid collisions with files named 'ecosa'
+    const baseDir = join(process.cwd(), '.ecosa');
+    const queuesDir = join(baseDir, 'queues');
+    ensureDir(queuesDir);
+    const filePath = join(queuesDir, `${name}.yaml`);
+    writeFileSync(filePath, input || '');
+
+    const stateDir = join(baseDir, 'state');
+    ensureDir(stateDir);
+    const stateFile = join(stateDir, 'queues.json');
+    let state = { queues: [] };
+    if (existsSync(stateFile)) {
+      try {
+        state = JSON.parse(readFileSync(stateFile, 'utf8') || '{"queues":[]}');
+      } catch {}
+    }
+    const meta = { name, createdAt: new Date().toISOString(), path: filePath };
+    const idx = state.queues.findIndex((q) => q.name === name);
+    if (idx >= 0) state.queues[idx] = meta; else state.queues.push(meta);
+    writeFileSync(stateFile, JSON.stringify(state, null, 2));
+
+    console.log(`Queue '${name}' created at ${filePath}`);
+    process.exit(0);
+  }
+
+  if (cmd === 'job' && args[1] === 'create') {
+    const queueName = args[2];
+    if (!queueName) {
+      console.error('Usage: ecosa job create <queue> --name <jobName>');
+      process.exit(1);
+    }
+    let jobName = null;
+    for (let i = 3; i < args.length; i++) {
+      if (args[i] === '--name' || args[i] === '-n') {
+        jobName = args[i + 1];
+        i++;
+      }
+    }
+    if (!jobName) jobName = `job_${Date.now()}`;
+
+    const input = await readStdin();
+
+    const baseDir = join(process.cwd(), '.ecosa');
+    const jobsDir = join(baseDir, 'jobs', queueName);
+    ensureDir(jobsDir);
+    const filePath = join(jobsDir, `${jobName}.yaml`);
+    writeFileSync(filePath, input || '');
+
+    const stateDir = join(baseDir, 'state');
+    ensureDir(stateDir);
+    const stateFile = join(stateDir, 'jobs.json');
+    let state = { jobs: [] };
+    if (existsSync(stateFile)) {
+      try {
+        state = JSON.parse(readFileSync(stateFile, 'utf8') || '{"jobs":[]}');
+      } catch {}
+    }
+    const meta = { name: jobName, queue: queueName, createdAt: new Date().toISOString(), path: filePath };
+    state.jobs.push(meta);
+    writeFileSync(stateFile, JSON.stringify(state, null, 2));
+
+    console.log(`Job '${jobName}' for queue '${queueName}' created at ${filePath}`);
+    process.exit(0);
+  }
+
+  console.error('Unknown command. Supported: queue create, job create');
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
Add a local `ecosa` CLI stub and create workflow definition files to simulate queue and job creation.

The `ecosa` CLI was not found on the system. To allow the user to proceed with defining their workflow and jobs, a local Node.js-based CLI stub was created. This stub supports `ecosa queue create` and `ecosa job create` commands, persisting the workflow and job definitions as YAML files in a `.ecosa` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-3751d2d4-a337-4fac-a440-9e565cae242a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3751d2d4-a337-4fac-a440-9e565cae242a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

